### PR TITLE
feat[SCRUM-50]: 여행 이름 비선형 페이지 구현 / travelType 쿼리에 따른 조건부 렌더링

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-54d0af47'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.6nvv95kdq58"
+    "revision": "0.l6rlr719ceg"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-54d0af47'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.l6rlr719ceg"
+    "revision": "0.0krl048lev8"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-54d0af47'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.0krl048lev8"
+    "revision": "0.tt8o2ka2v0o"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/pages/setup/setTravelGoal/_components/SetTravelHeader.tsx
+++ b/src/pages/setup/setTravelGoal/_components/SetTravelHeader.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router';
 import arrowBackIcon from '../../../../assets/icons/arrow_back.svg';
 
 interface SetTravelHeaderProps {
-    title: JSX.Element;
+    title: (userName: string) => JSX.Element;
     description?: string;
 }
 

--- a/src/pages/setup/setTravelGoal/_components/SetTravelHeader.tsx
+++ b/src/pages/setup/setTravelGoal/_components/SetTravelHeader.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router';
 import arrowBackIcon from '../../../../assets/icons/arrow_back.svg';
 
 interface SetTravelHeaderProps {
-    title: (userName: string) => JSX.Element;
+    title: JSX.Element;
     description?: string;
 }
 

--- a/src/pages/setup/setTravelGoal/setTravelName/SetTravelNameForm.tsx
+++ b/src/pages/setup/setTravelGoal/setTravelName/SetTravelNameForm.tsx
@@ -60,7 +60,12 @@ const SetTravelNameForm = ({ travelType }: SetTravelNameFormProps) => {
                     alt="calendar"
                     className="absolute top-1/2 right-4 w-6 -translate-y-1/2 cursor-pointer"
                 />
-                <span className="text-point1 text-small">
+                <span
+                    className={clsx(
+                        'text-small',
+                        travelType === 'course' ? 'text-point1' : 'text-primary'
+                    )}
+                >
                     {ENDDATE_HELPER_TEXT[travelType]}
                 </span>
             </div>

--- a/src/pages/setup/setTravelGoal/setTravelName/SetTravelNameForm.tsx
+++ b/src/pages/setup/setTravelGoal/setTravelName/SetTravelNameForm.tsx
@@ -5,18 +5,18 @@ import { getTodayDate } from '../../../../utils/date';
 import CalendarIcon from '../../../../assets/icons/calendar_icon.svg';
 
 interface SetTravelNameFormProps {
-    travelType: 'COURSE' | 'EXPLORE';
+    travelType: 'course' | 'explore';
 }
 
 const SetTravelNameForm = ({ travelType }: SetTravelNameFormProps) => {
     const ENDDATE_INPUT_TEXT = {
-        COURSE: '2025년 8월 1일',
-        EXPLORE: '설정 안함',
+        course: '2025년 8월 1일',
+        explore: '설정 안함',
     };
 
     const ENDDATE_HELPER_TEXT = {
-        COURSE: '* 필수로 입력해주세요.',
-        EXPLORE: '* 선택사항입니다.',
+        course: '* 필수로 입력해주세요.',
+        explore: '* 선택사항입니다.',
     };
 
     const [travelName, setTravelName] = useState('');

--- a/src/pages/setup/setTravelGoal/setTravelName/SetTravelNameForm.tsx
+++ b/src/pages/setup/setTravelGoal/setTravelName/SetTravelNameForm.tsx
@@ -4,7 +4,21 @@ import { useNavigate } from 'react-router';
 import { getTodayDate } from '../../../../utils/date';
 import CalendarIcon from '../../../../assets/icons/calendar_icon.svg';
 
-const SetTravelNameForm = () => {
+interface SetTravelNameFormProps {
+    travelType: 'COURSE' | 'EXPLORE';
+}
+
+const SetTravelNameForm = ({ travelType }: SetTravelNameFormProps) => {
+    const ENDDATE_INPUT_TEXT = {
+        COURSE: '2025년 8월 1일',
+        EXPLORE: '설정 안함',
+    };
+
+    const ENDDATE_HELPER_TEXT = {
+        COURSE: '* 필수로 입력해주세요.',
+        EXPLORE: '* 선택사항입니다.',
+    };
+
     const [travelName, setTravelName] = useState('');
 
     const isDisabled = travelName.trim() === '';
@@ -39,7 +53,7 @@ const SetTravelNameForm = () => {
                     <span className="text-point1"> *</span>
                 </label>
                 <span className="text-text-min/40 text-subtitle bg-input-focus border-input-sub h-[50px] cursor-pointer rounded-md border py-2.5 pl-[15px]">
-                    2025년 8월 1일
+                    {ENDDATE_INPUT_TEXT[travelType]}
                 </span>
                 <img
                     src={CalendarIcon}
@@ -47,7 +61,7 @@ const SetTravelNameForm = () => {
                     className="absolute top-1/2 right-4 w-6 -translate-y-1/2 cursor-pointer"
                 />
                 <span className="text-point1 text-small">
-                    * 필수로 입력해주세요.{' '}
+                    {ENDDATE_HELPER_TEXT[travelType]}
                 </span>
             </div>
 

--- a/src/pages/setup/setTravelGoal/setTravelName/index.tsx
+++ b/src/pages/setup/setTravelGoal/setTravelName/index.tsx
@@ -2,42 +2,33 @@ import { useSearchParams } from 'react-router';
 import SetTravelHeader from '../_components/SetTravelHeader';
 import SetTravelNameForm from './SetTravelNameForm';
 
+type travelType = 'course' | 'explore';
+
 const SetTravelNamePage = () => {
     const userName = '수진';
 
-    // url 에서 가져와서 form 조건부 렌더링
-    // 코스형 -> title={titleMap.course} // SetTravelHeader
-    // 코스형 -> travelType="COURSE" // SetTravelNameForm
-
     const searchParams = useSearchParams()[0];
-    const travelType = searchParams.get('type') || 'course'; // 기본값 : 'course'
-    console.log(travelType);
+    const travelType = searchParams.get('type') as travelType;
 
-    const TRAVEL_TYPE_MAP = {
-        COURSE: {
-            title: (userName: string) => (
-                <>
-                    코스형을 선택한 {userName}님, <br />
-                    여행의 여정을 계획해봐요!
-                </>
-            ),
-            formType: 'COURSE',
-        },
-        EXPLORE: {
-            title: (userName: string) => (
-                <>
-                    자유형을 선택한 {userName}님, <br />
-                    여행의 여정을 계획해봐요!
-                </>
-            ),
-            formType: 'EXPLORE',
-        },
+    const travelTypeMap = {
+        course: (
+            <>
+                코스형을 선택한 {userName}님, <br />
+                여행의 여정을 계획해봐요!
+            </>
+        ),
+        explore: (
+            <>
+                탐험형을 선택한 {userName}님, <br />
+                여행의 여정을 계획해봐요!
+            </>
+        ),
     };
 
     return (
         <div className="pt-[106px] pb-20">
-            <SetTravelHeader title={TRAVEL_TYPE_MAP.EXPLORE.title} />
-            <SetTravelNameForm travelType={TRAVEL_TYPE_MAP.EXPLORE.formType} />
+            <SetTravelHeader title={travelTypeMap[travelType]} />
+            <SetTravelNameForm travelType={travelType} />
         </div>
     );
 };

--- a/src/pages/setup/setTravelGoal/setTravelName/index.tsx
+++ b/src/pages/setup/setTravelGoal/setTravelName/index.tsx
@@ -1,19 +1,43 @@
+import { useSearchParams } from 'react-router';
 import SetTravelHeader from '../_components/SetTravelHeader';
 import SetTravelNameForm from './SetTravelNameForm';
 
 const SetTravelNamePage = () => {
     const userName = '수진';
+
+    // url 에서 가져와서 form 조건부 렌더링
+    // 코스형 -> title={titleMap.course} // SetTravelHeader
+    // 코스형 -> travelType="COURSE" // SetTravelNameForm
+
+    const searchParams = useSearchParams()[0];
+    const travelType = searchParams.get('type') || 'course'; // 기본값 : 'course'
+    console.log(travelType);
+
+    const TRAVEL_TYPE_MAP = {
+        COURSE: {
+            title: (userName: string) => (
+                <>
+                    코스형을 선택한 {userName}님, <br />
+                    여행의 여정을 계획해봐요!
+                </>
+            ),
+            formType: 'COURSE',
+        },
+        EXPLORE: {
+            title: (userName: string) => (
+                <>
+                    자유형을 선택한 {userName}님, <br />
+                    여행의 여정을 계획해봐요!
+                </>
+            ),
+            formType: 'EXPLORE',
+        },
+    };
+
     return (
         <div className="pt-[106px] pb-20">
-            <SetTravelHeader
-                title={
-                    <>
-                        코스형을 선택한 {userName}님, <br />
-                        여행의 여정을 계획해봐요!
-                    </>
-                }
-            />
-            <SetTravelNameForm />
+            <SetTravelHeader title={TRAVEL_TYPE_MAP.EXPLORE.title} />
+            <SetTravelNameForm travelType={TRAVEL_TYPE_MAP.EXPLORE.formType} />
         </div>
     );
 };

--- a/src/pages/setup/setTravelGoal/setTravelType/TravelTypeCard.tsx
+++ b/src/pages/setup/setTravelGoal/setTravelType/TravelTypeCard.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router';
 
 type TravelTypeCardProps = {
-    name: 'linear' | 'nonLinear';
+    name: 'course' | 'explore';
     title: string;
     description: string;
     recommend: string;
@@ -14,17 +14,17 @@ const TravelTypeCard = ({
     recommend,
 }: TravelTypeCardProps) => {
     const colorMap = {
-        linear: 'text-point2',
-        nonLinear: 'text-point1',
+        course: 'text-point2',
+        explore: 'text-point1',
     };
 
     const titleColor = colorMap[name] || 'text-point2';
     const navigate = useNavigate();
 
-    const handleCardClicked = (selectedName: 'linear' | 'nonLinear') => {
+    const handleCardClicked = (selectedName: 'course' | 'explore') => {
         const paths = {
-            linear: '/set-travel-name',
-            nonLinear: '/set-travel-name',
+            course: `/set-travel-name?type=${selectedName}`,
+            explore: `/set-travel-name?type=${selectedName}`,
         };
 
         navigate(paths[selectedName]);

--- a/src/pages/setup/setTravelGoal/setTravelType/TravelTypeList.tsx
+++ b/src/pages/setup/setTravelGoal/setTravelType/TravelTypeList.tsx
@@ -3,7 +3,7 @@ import TravelTypeCard from './TravelTypeCard';
 export default function TravelTypeList() {
     const travelTypes = [
         {
-            name: 'linear',
+            name: 'course',
             title: '코스형',
             color: 'text-point2',
             description: '계획된 순서와 단계에 따라 진행하는 목표입니다.',
@@ -11,7 +11,7 @@ export default function TravelTypeList() {
                 '자격증 취득이나 시험 준비를 하고 계신 분들에게 추천해요',
         },
         {
-            name: 'nonLinear',
+            name: 'explore',
             title: '탐험형',
             color: 'text-point1',
             description: '정해진 경로 없이 자유롭게 나아가는 목표입니다.',


### PR DESCRIPTION
## 🔗 관련 이슈
- [[JECT-4-client #SCRUM-50]](https://ject-plog.atlassian.net/jira/software/projects/SCRUM/boards/1/backlog?selectedIssue=SCRUM-50&atlOrigin=eyJpIjoiOGE4Y2QwMTg5YTIxNDdmZjhlNmVhZGYxOTNlZTNmMTciLCJwIjoiaiJ9)

## 📌 Summary
여행 이름 설정 페이지 (비선형) 구현 

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 변경 사항
- SetGoalTypePage : travelType 쿼리에 따른 조건부 헤더 및 입력 폼 렌더링
- 여행 타입에 따른 도착일 필드 텍스트(`ENDDATE_INPUT_TEXT`), 헬퍼 텍스트(`ENDDATE_HELPER_TEXT`) 조건부 렌더링

## 📱 스크린샷/화면 기록
<img width="298" height="605" alt="스크린샷 2025-07-24 오후 7 26 34" src="https://github.com/user-attachments/assets/14659da7-66a8-403c-975f-bbb730f24e8f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 여행 타입(코스/탐험)에 따라 여행 이름 설정 화면의 안내 문구와 입력란 텍스트가 동적으로 변경됩니다.
  * 여행 타입 선택 시, 해당 타입이 쿼리 파라미터로 전달되어 이후 화면에서 맞춤형 안내가 제공됩니다.

* **버그 수정**
  * 여행 타입 명칭이 'linear/ nonLinear'에서 'course/ explore'로 일관성 있게 변경되었습니다.

* **스타일**
  * 여행 타입에 따라 안내 문구 색상이 다르게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->