### PR TITLE
feat[#58] : 뽀모도로 타이머 임시처리 삭제

### DIFF
--- a/src/pages/auth/LoginPage/KakaoLoginAccessPage.tsx
+++ b/src/pages/auth/LoginPage/KakaoLoginAccessPage.tsx
@@ -48,14 +48,15 @@ function KakaoLoginAccessPage() {
                     navigate('/main', { replace: true });
                 } catch (error) {
                     const err = error as AxiosError;
-                    if (err.response?.status === 404) {
+                    if (err.response?.status === 409) {
+                        console.warn('로그인 실패, 신규 회원 처리', error);
+
+                        localStorage.setItem('loginCheck', 'true');
+                        window.location.href = kakaoURL;
+                    } else {
                         alert('로그인에 문제가 발생했습니다.');
                         navigate('/', { replace: true });
                     }
-                    console.warn('로그인 실패, 신규 회원 처리', error);
-
-                    localStorage.setItem('loginCheck', 'true');
-                    window.location.href = kakaoURL;
                 }
             } else {
                 // 새 code가 있으면 userInfo에 저장하고 /set-name으로 이동

--- a/src/pages/auth/LoginPage/KakaoLoginAccessPage.tsx
+++ b/src/pages/auth/LoginPage/KakaoLoginAccessPage.tsx
@@ -1,5 +1,7 @@
 import { useNavigate, useSearchParams } from 'react-router';
 import { useEffect } from 'react';
+import { AxiosError } from 'axios';
+
 import api from '@lib/axios';
 import { useAtom } from 'jotai';
 import { signupUserInfoAtom } from '../../../store/signupUserInfoAtom';
@@ -41,9 +43,15 @@ function KakaoLoginAccessPage() {
                     );
 
                     console.log('로그인 성공');
+
                     localStorage.setItem('loginCheck', 'false');
                     navigate('/main', { replace: true });
                 } catch (error) {
+                    const err = error as AxiosError;
+                    if (err.response?.status === 404) {
+                        alert('로그인에 문제가 발생했습니다.');
+                        navigate('/', { replace: true });
+                    }
                     console.warn('로그인 실패, 신규 회원 처리', error);
 
                     localStorage.setItem('loginCheck', 'true');

--- a/src/pages/auth/LoginPage/KakaoLoginAccessPage.tsx
+++ b/src/pages/auth/LoginPage/KakaoLoginAccessPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useSearchParams } from 'react-router';
 import { useEffect } from 'react';
-import axios from 'axios';
+import api from '@lib/axios';
 import { useAtom } from 'jotai';
 import { signupUserInfoAtom } from '../../../store/signupUserInfoAtom';
 
@@ -26,7 +26,7 @@ function KakaoLoginAccessPage() {
             // 로그인 api 호출 여부 확인
             if (localStorage.getItem('loginCheck') !== 'true') {
                 try {
-                    const response = await axios.post('/api/auth/login/kakao', {
+                    const response = await api.post('/auth/login/kakao', {
                         code,
                     });
 

--- a/src/pages/pomodoro/PomodoroMissionItem.tsx
+++ b/src/pages/pomodoro/PomodoroMissionItem.tsx
@@ -2,10 +2,17 @@ type missionProps = {
     id: number;
     name: string;
     checked: boolean;
+    disabled: boolean;
     onToggle: () => void;
 };
 
-const PomodoroMissionItem = ({ id, name, checked, onToggle }: missionProps) => {
+const PomodoroMissionItem = ({
+    id,
+    name,
+    checked,
+    disabled,
+    onToggle,
+}: missionProps) => {
     return (
         <div className="flex items-center">
             <input
@@ -14,6 +21,7 @@ const PomodoroMissionItem = ({ id, name, checked, onToggle }: missionProps) => {
                 checked={checked}
                 onChange={onToggle}
                 className="accent-text-sub h-5 w-5"
+                disabled={disabled}
             />
             <label htmlFor={String(id)} className="ml-4">
                 {name}

--- a/src/pages/pomodoro/PomodoroMissionItem.tsx
+++ b/src/pages/pomodoro/PomodoroMissionItem.tsx
@@ -1,7 +1,6 @@
 type missionProps = {
     id: number;
     name: string;
-    memo: string;
     checked: boolean;
     onToggle: () => void;
 };

--- a/src/pages/pomodoro/PomodoroMissionModal.tsx
+++ b/src/pages/pomodoro/PomodoroMissionModal.tsx
@@ -8,6 +8,7 @@ interface DailyMission {
 
 type Props = {
     isAutoStop: boolean;
+    isStarted: boolean;
     stampName: string;
     focusDurationInMinute: number;
     dailyMissions: DailyMission[];
@@ -16,6 +17,7 @@ type Props = {
 
 const PomodoroMissionModal = ({
     isAutoStop,
+    isStarted,
     stampName,
     focusDurationInMinute,
     dailyMissions,
@@ -56,6 +58,7 @@ const PomodoroMissionModal = ({
                         name={mission.missionName}
                         checked={checkedIds.includes(mission.dailyMissionId)} // ✅ 체크 상태 전달
                         onToggle={() => handleToggle(mission.dailyMissionId)} // ✅ 클릭 핸들러
+                        disabled={!isStarted}
                     />
                 ))}
             </div>

--- a/src/pages/pomodoro/PomodoroMissionModal.tsx
+++ b/src/pages/pomodoro/PomodoroMissionModal.tsx
@@ -4,7 +4,6 @@ import PomodoroMissionItem from './PomodoroMissionItem';
 interface DailyMission {
     dailyMissionId: number;
     missionName: string;
-    missionMemo: string;
 }
 
 type Props = {
@@ -55,7 +54,6 @@ const PomodoroMissionModal = ({
                         key={mission.dailyMissionId}
                         id={mission.dailyMissionId}
                         name={mission.missionName}
-                        memo={mission.missionMemo}
                         checked={checkedIds.includes(mission.dailyMissionId)} // ✅ 체크 상태 전달
                         onToggle={() => handleToggle(mission.dailyMissionId)} // ✅ 클릭 핸들러
                     />

--- a/src/pages/pomodoro/PomodoroPage.tsx
+++ b/src/pages/pomodoro/PomodoroPage.tsx
@@ -16,7 +16,6 @@ interface Pomodoro {
 interface DailyMission {
     dailyMissionId: number;
     missionName: string;
-    missionMemo: string;
 }
 
 interface DailyGoal {

--- a/src/pages/pomodoro/PomodoroPage.tsx
+++ b/src/pages/pomodoro/PomodoroPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import PomodoroTimer from './PomodoroTimer';
 import PomodoroButton from './PomodoroButton';
 import PomodoroMissionModal from './PomodoroMissionModal';
@@ -42,8 +42,9 @@ const defaultDailyGoal: DailyGoal = {
 
 const PomodoroPage = () => {
     const navigate = useNavigate();
-    const tripId = 15; // 임시
-    const dailyGoalId = 1; // 임시
+    const location = useLocation();
+
+    const { tripId, dailyGoalId } = location.state || {};
     const [dailyGoal, setDailyGoal] = useState(defaultDailyGoal);
 
     useEffect(() => {
@@ -62,50 +63,30 @@ const PomodoroPage = () => {
         fetchDailyGoal();
     }, []);
 
-    // TODO : 스탬프 이름 출력
-    // TODO : 완료한 미션 ID 담아서 넘기기
     const totalTime =
         dailyGoal.pomodoro.focusDurationInMinute *
         dailyGoal.pomodoro.focusSessionCount *
-        60; // 총 75분
-    const [elapsedTime, setElapsedTime] = useState(0); //경과한 시간(초)
+        60; // 전체시간
     const [isRunning, setIsRunning] = useState(false); //타이머가 작동 중인지 여부
     const [isStarted, setIsStarted] = useState(false); //타이머가 시작했는지 여부
-    const intervalRef = useRef<number | null>(null);
     const [isAutoStop, setIsAutoStop] = useState(false);
     const [checkedMissionIds, setCheckedMissionIds] = useState<number[]>([]); //완료된 미션 객체 넘기기
 
+    const intervalRef = useRef<number | null>(null);
+    const elapsedTimeRef = useRef(0); //총 경과한 시간
+    const [sessionElapsedTime, setSessionElapsedTime] = useState(0); //현재 세션에서 경과한 시간(초)
+    const [currentSession, setCurrentSession] = useState(0); // 진행 중인 세션 번호
+
     const sessionLength = dailyGoal.pomodoro.focusDurationInMinute * 60;
-    const completedSessions = Math.ceil(elapsedTime / sessionLength);
-
-    // 자동 정지 타이밍 계산
-    const getPausePoints = (duration: number, step: number) => {
-        if (step <= 0) return [];
-        return Array.from({ length: step - 1 }, (_, i) => duration * (i + 1));
-    };
-
-    const shouldPauseAt = useRef<number[]>(
-        getPausePoints(
-            dailyGoal.pomodoro.focusDurationInMinute * 60,
-            dailyGoal.pomodoro.focusSessionCount
-        )
-    );
-
-    useEffect(() => {
-        shouldPauseAt.current = getPausePoints(
-            dailyGoal.pomodoro.focusDurationInMinute * 60,
-            dailyGoal.pomodoro.focusSessionCount
-        );
-    }, [totalTime, dailyGoal]);
+    const completedSessions = Math.ceil(elapsedTimeRef.current / sessionLength);
 
     const endingAction = () => {
         if (intervalRef.current !== null) {
             clearInterval(intervalRef.current);
             intervalRef.current = null;
         }
-        setIsRunning(false);
-        const finalElapsedTime = elapsedTime;
-        setElapsedTime(finalElapsedTime);
+
+        const finalElapsedTime = elapsedTimeRef.current;
 
         // 완료 미션 담아서 넘기기
         const updatedDailyGoal = {
@@ -124,15 +105,25 @@ const PomodoroPage = () => {
     };
 
     useEffect(() => {
-        if (!isRunning) return;
+        if (!isRunning) {
+            if (isAutoStop) {
+                setSessionElapsedTime(0);
+                return;
+            } else return;
+        }
 
-        const start = Date.now() - elapsedTime * 1000;
+        const start = Date.now() - elapsedTimeRef.current * 1000;
 
         intervalRef.current = window.setInterval(() => {
-            const nowElapsed = Math.floor((Date.now() - start) / 1000);
-            setElapsedTime(nowElapsed);
+            const nowElapsed = Math.floor((Date.now() - start) / 1000); //현재 진행한 총 시간
+            const nowSessionElapsed =
+                nowElapsed -
+                dailyGoal.pomodoro.focusDurationInMinute * 60 * currentSession;
+            elapsedTimeRef.current = nowElapsed;
+            setSessionElapsedTime(nowSessionElapsed);
 
-            if (shouldPauseAt.current.includes(nowElapsed)) {
+            if (nowSessionElapsed >= sessionLength) {
+                //현재 경과시간이 초과했을 때
                 setIsRunning(false); // 자동 멈춤
                 setIsAutoStop(true);
             }
@@ -152,6 +143,10 @@ const PomodoroPage = () => {
 
     const handlePause = () => setIsRunning(false);
     const handleResume = () => {
+        if (isAutoStop) {
+            // 휴식 후 재시작할 경우
+            setCurrentSession((prev) => prev + 1); // 세션 번호 증가
+        }
         setIsRunning(true);
         setIsAutoStop(false);
     };
@@ -159,7 +154,8 @@ const PomodoroPage = () => {
         setIsStarted(false);
         setIsRunning(false);
         setIsAutoStop(false);
-        setElapsedTime(0);
+        setSessionElapsedTime(0);
+        setCurrentSession(0);
 
         endingAction();
     };
@@ -172,8 +168,8 @@ const PomodoroPage = () => {
             />
             <div className="flex flex-col items-center pt-20">
                 <PomodoroTimer
-                    duration={totalTime}
-                    elapsedTime={elapsedTime}
+                    duration={sessionLength}
+                    elapsedTime={sessionElapsedTime}
                     width={250}
                 />
                 {/* 세션 점 표시 */}
@@ -195,6 +191,7 @@ const PomodoroPage = () => {
                 <div className="mt-9 w-full">
                     <PomodoroMissionModal
                         stampName={dailyGoal.title}
+                        isStarted={isStarted}
                         isAutoStop={isAutoStop}
                         focusDurationInMinute={
                             dailyGoal.pomodoro.focusDurationInMinute

--- a/src/pages/pomodoro/log/LogMissionItem.tsx
+++ b/src/pages/pomodoro/log/LogMissionItem.tsx
@@ -1,7 +1,6 @@
 interface LogMissionItemProps {
     id: number;
     name: string;
-    memo?: string;
     checked: boolean;
     onToggle: (id: number) => void;
 }

--- a/src/pages/pomodoro/log/LogPage.tsx
+++ b/src/pages/pomodoro/log/LogPage.tsx
@@ -11,7 +11,6 @@ import LogMissionItem from './LogMissionItem';
 interface DailyMission {
     dailyMissionId: number;
     missionName: string;
-    missionMemo: string;
     checked: boolean;
 }
 

--- a/src/pages/setup/setProfile/SetJobPage.tsx
+++ b/src/pages/setup/setProfile/SetJobPage.tsx
@@ -6,7 +6,7 @@ import MainButton from '../../../components/common/button/MainButton';
 import { useAtom } from 'jotai';
 import { signupUserInfoAtom } from '../../../store/signupUserInfoAtom';
 
-import axios from 'axios';
+import api from 'axios';
 
 function SetJobPage() {
     const [selected, setSelected] = useState<string>('');
@@ -27,8 +27,8 @@ function SetJobPage() {
         setUserInfo(updatedUserInfo);
 
         try {
-            const response = await axios.post(
-                '/api/auth/signup/kakao',
+            const response = await api.post(
+                '/auth/signup/kakao',
                 updatedUserInfo
             );
 

--- a/src/pages/setup/setTravelGoal/setStamp/StampModal.tsx
+++ b/src/pages/setup/setTravelGoal/setStamp/StampModal.tsx
@@ -5,6 +5,7 @@ import { useAtom } from 'jotai';
 import { memberNameAtom, fetchMemberNameAtom } from '@store/userInfoAtom';
 
 interface ModalProps {
+    stampName: string;
     isOpen: boolean;
     onClose: () => void;
     onConfirm?: () => void;
@@ -13,7 +14,13 @@ interface ModalProps {
     children?: React.ReactNode;
 }
 
-const Modal = ({ isOpen, onClose, onConfirm, children }: ModalProps) => {
+const Modal = ({
+    stampName,
+    isOpen,
+    onClose,
+    onConfirm,
+    children,
+}: ModalProps) => {
     // 유저이름 불러오기
     const [userName] = useAtom(memberNameAtom);
     const [, fetchMemberName] = useAtom(fetchMemberNameAtom);
@@ -44,8 +51,8 @@ const Modal = ({ isOpen, onClose, onConfirm, children }: ModalProps) => {
                     <div className="px-8">
                         {userName}님의 여정이 완성되었어요!
                         <br />
-                        <span className="text-text-sub">ㅇㅇ 여행</span>을
-                        시작해볼까요?
+                        <span className="text-text-sub">{stampName} 여행</span>
+                        을 시작해볼까요?
                     </div>
                 </div>
                 <div className="text-secondary my-2 max-h-72 overflow-y-auto px-8">

--- a/src/pages/setup/setTravelGoal/setStamp/index.tsx
+++ b/src/pages/setup/setTravelGoal/setStamp/index.tsx
@@ -83,6 +83,7 @@ const SetStampLinearPage = () => {
                 ></MainButton>
             </section>
             <Modal
+                stampName={prevTravelInfo.name}
                 isOpen={isOpen}
                 onClose={handleCancel}
                 onConfirm={handleConfirm}


### PR DESCRIPTION
## 🔗 관련 이슈

https://ject-plog.atlassian.net/browse/SCRUM-58

## 📌 Summary

뽀모도로 타이머 임시 처리 삭제

## PR 유형

<!-- 어떤 변경 사항이 있나요? -->

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 변경 사항

- 미션 메모 필드 삭제
- 로그인 api 에러랑 로그인 실패 구분
- 뽀모도로 임시 아이디 삭제
- 뽀모도로 세션별 타이머로 변

## 📜 공유 사항


## 📱 스크린샷/화면 기록







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 포모도로 타이머가 다중 세션을 지원하며 자동 세션 종료·재개를 제공합니다.
  - 포모도로 미션 체크박스가 타이머 시작 전 비활성화됩니다.
  - 스탬프 설정 모달에서 여행 이름이 동적으로 표시됩니다.
  - 카카오 로그인 성공 시 토큰 저장 및 신규 회원 분기 처리가 개선되었습니다.

- Refactor
  - API 호출을 중앙화된 래퍼로 전환하고 엔드포인트를 정리했습니다.
  - 포모도로/로그 미션의 메모 필드를 제거해 데이터 구조를 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->