### PR TITLE
feat[#67]: 스탬프 기능 관련 버그 수정

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-54d0af47'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.dp3iq5uftrg"
+    "revision": "0.q2co5ffmlc"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/common/BackHeaderLayout.tsx
+++ b/src/components/common/BackHeaderLayout.tsx
@@ -34,7 +34,7 @@ const BackHeader = ({
                     <LeftArrow className="h-4 w-4" />
                 </button>
             )}
-            <div className="text-text-sub text-subtitle flex-1 text-center font-semibold">
+            <div className="text-text-sub text-subtitle line-clamp-1 flex-1 text-center font-semibold">
                 {title}
             </div>
             {hideLogButton ? (

--- a/src/hooks/stamp/useCompleteStamp.ts
+++ b/src/hooks/stamp/useCompleteStamp.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { completeStamp } from '../../services/stamp/stamps';
+import type { ResponseDTO, MutationStampProps } from '../../types/stamp';
+import { toast } from 'react-toastify';
+
+const useCompleteStamp = () => {
+    const queryClient = useQueryClient();
+
+    const { mutate, ...rest } = useMutation<
+        ResponseDTO,
+        Error,
+        MutationStampProps
+    >({
+        mutationFn: async ({ tripId, stampId }) => {
+            return completeStamp(tripId, stampId);
+        },
+        onSuccess: (_, variables) => {
+            queryClient.invalidateQueries({
+                queryKey: ['stamp', variables.tripId, variables.stampId],
+            });
+        },
+        onError: () => {
+            toast.error('스탬프를 완료하지 못했습니다.');
+        },
+    });
+
+    return { mutateCompleteStamp: mutate, ...rest };
+};
+
+export default useCompleteStamp;

--- a/src/hooks/stamp/useDetailStampQuery.ts
+++ b/src/hooks/stamp/useDetailStampQuery.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import type { StampDetail } from '../../types/stamp';
+import { fetchStampDetail } from '../../services/stamp/stamps';
+
+const useDetailStampQuery = (tripId: number, stampId: number) => {
+    return useQuery<StampDetail, Error>({
+        queryKey: ['stamp', tripId, stampId],
+        queryFn: () => {
+            if (!tripId || !stampId) {
+                throw new Error('스탬프를 조회할 수 없습니다.');
+            }
+
+            return fetchStampDetail(tripId, stampId);
+        },
+        enabled: !!tripId && !!stampId,
+        staleTime: 60_000,
+    });
+};
+
+export default useDetailStampQuery;

--- a/src/pages/pomodoro/log/LogPage.tsx
+++ b/src/pages/pomodoro/log/LogPage.tsx
@@ -1,3 +1,4 @@
+import { useSetAtom } from 'jotai';
 import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -7,6 +8,7 @@ import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 import MainButton from '../../../components/common/button/MainButton';
 import LogMissionItem from './LogMissionItem';
+import { missionsAtom } from '../../../store/mission';
 
 interface DailyMission {
     dailyMissionId: number;
@@ -15,6 +17,8 @@ interface DailyMission {
 }
 
 const LogPage = () => {
+    const setMissions = useSetAtom(missionsAtom);
+
     const navigate = useNavigate();
     const location = useLocation();
 
@@ -69,6 +73,16 @@ const LogPage = () => {
                     selectedDailyMissionIds: checkedIds,
                     content: text,
                 }
+            );
+
+            setMissions((prevMissions) =>
+                prevMissions.map((mission) => {
+                    if (checkedIds.includes(Number(mission.missionId))) {
+                        return { ...mission, completed: true, isChecked: true };
+                    }
+
+                    return mission;
+                })
             );
 
             alert('공부 기록이 생성되었습니다.');

--- a/src/pages/trip/TripPage.tsx
+++ b/src/pages/trip/TripPage.tsx
@@ -96,7 +96,7 @@ const TripPage = () => {
             <div className="h-[4rem]">
                 <BackHeader title={data?.name} hideLogButton={false} />
             </div>
-            <div className="h-[calc(100vh-10rem)] overflow-y-auto pt-[4rem] [&::-webkit-scrollbar]:hidden">
+            <div className="h-[calc(100vh-10rem)] overflow-y-auto pt-[8rem] [&::-webkit-scrollbar]:hidden">
                 {steps.map((step) => (
                     <GoalStep
                         key={`${data?.tripId}-${step.sequence}`}

--- a/src/pages/trip/_components/GoalStep.tsx
+++ b/src/pages/trip/_components/GoalStep.tsx
@@ -86,7 +86,7 @@ const GoalStep: React.FC<GoalStepProps> = ({
                 )}
                 {align !== 'right' && <>{titleAlign('pl-4')}</>}
             </div>
-            <div className="flex justify-center pl-[0.25rem]">
+            <div className="flex justify-center">
                 {!isLast && (
                     <svg
                         xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/trip/_components/GoalStep.tsx
+++ b/src/pages/trip/_components/GoalStep.tsx
@@ -54,7 +54,7 @@ const GoalStep: React.FC<GoalStepProps> = ({
                 {sequence}
             </h5>
             <p
-                className={`${goalStateTitleStyleClass[goalState]} text-base whitespace-pre-wrap`}
+                className={`${goalStateTitleStyleClass[goalState]} line-clamp-2 truncate text-base whitespace-pre-wrap`}
             >
                 {title}
             </p>

--- a/src/pages/trip/_components/GoalStep.tsx
+++ b/src/pages/trip/_components/GoalStep.tsx
@@ -62,7 +62,7 @@ const GoalStep: React.FC<GoalStepProps> = ({
     );
 
     return (
-        <div className="flex flex-col">
+        <div className="relative flex flex-col">
             <div className={`flex ${alignStyleClass[align]}`}>
                 {align === 'right' && <>{titleAlign('pr-4 text-right')}</>}
                 {goalState === 'goal' ? (

--- a/src/pages/trip/_styles/styleClasses.ts
+++ b/src/pages/trip/_styles/styleClasses.ts
@@ -1,7 +1,7 @@
 export const alignStyleClass = {
     left: 'justify-start pl-[1.25rem]',
     right: 'justify-end pr-[1.3rem]',
-    center: 'justify-center pl-[6.25rem]',
+    center: 'absolute justify-center top-[17%] left-[59%] transform translate-x-[-50%] translate-y-[-50%]',
 } as const;
 
 export const goalStateNumberStyleClass = {

--- a/src/pages/trip/_styles/styleClasses.ts
+++ b/src/pages/trip/_styles/styleClasses.ts
@@ -1,7 +1,7 @@
 export const alignStyleClass = {
     left: 'justify-start pl-[1.25rem]',
     right: 'justify-end pr-[1.3rem]',
-    center: 'absolute justify-center top-[17%] left-[59%] transform translate-x-[-50%] translate-y-[-50%]',
+    center: 'absolute justify-center top-[-30%] left-[58%] transform translate-x-[-50%] translate-y-[-50%]',
 } as const;
 
 export const goalStateNumberStyleClass = {

--- a/src/pages/trip/dashboard/DashboardPage.tsx
+++ b/src/pages/trip/dashboard/DashboardPage.tsx
@@ -66,7 +66,7 @@ export default function DashboardPage() {
 
     const {
         missions,
-        allChecked,
+        allCompletedMission,
         checkedCount,
         checkedMissionIds,
         addMission,
@@ -118,9 +118,9 @@ export default function DashboardPage() {
                 />
                 <MissionListSection
                     missions={missions}
-                    allChecked={allChecked}
                     checkedCount={checkedCount}
                     isEditMode={isEditMode}
+                    allCompleted={allCompletedMission}
                     onToggleEditMode={handleToggleEditMode}
                     addMission={addMission}
                     onUpdateLabel={updateLabel}
@@ -132,7 +132,7 @@ export default function DashboardPage() {
 
             <div className="pb-6">
                 <MainButton onClick={handleOpen} colorClass="bg-text-sub">
-                    {allChecked ? '스탬프 완료하기' : '학습 시작하기'}
+                    {allCompletedMission ? '스탬프 완료하기' : '학습 시작하기'}
                 </MainButton>
             </div>
 

--- a/src/pages/trip/dashboard/DashboardPage.tsx
+++ b/src/pages/trip/dashboard/DashboardPage.tsx
@@ -19,6 +19,8 @@ import useCreateDailyGoal, {
     type CreateDailyGoalSuccessResponse,
 } from '../../../hooks/dailyGoal/useCreateDailyGoal';
 
+import useDetailStampQuery from '../../../hooks/stamp/useDetailStampQuery';
+
 export default function DashboardPage() {
     const [isEditMode, setIsEditMode] = useState(false);
     const [open, setOpen] = useState(false);
@@ -32,9 +34,15 @@ export default function DashboardPage() {
 
     const {
         data: fetchedMissions,
-        isLoading,
-        isError,
+        isLoading: isMissionLoading,
+        isError: isMissionError,
     } = useMissionQuery(id.tripId!, id.stampId!);
+
+    const {
+        data: fetchedStamp,
+        isLoading: isStampLoading,
+        isError: isStampError,
+    } = useDetailStampQuery(id.tripId!, id.stampId!);
 
     const { mutateCreateDailyGoal } = useCreateDailyGoal({
         onSuccess: (data: CreateDailyGoalSuccessResponse) => {
@@ -65,8 +73,11 @@ export default function DashboardPage() {
         updateMissionOrder,
     } = useDashboardMissions(id.tripId!, id.stampId!, fetchedMissions);
 
-    if (isLoading) return <div>미션 목록 로드 중...</div>;
-    if (isError) alert('미션 목록을 불러올 수 없습니다.');
+    if (isMissionLoading) return <div>미션 목록 로드 중...</div>;
+    if (isMissionError) alert('미션 목록을 불러올 수 없습니다.');
+
+    if (isStampLoading) return <div>스탬프 로드 중...</div>;
+    if (isStampError) alert('스탬프를 로드할 수 없습니다.');
 
     const handleOpen = () => setOpen(true);
     const handleClose = () => setOpen(false);
@@ -91,7 +102,10 @@ export default function DashboardPage() {
     return (
         <div className="relative flex min-h-screen flex-col">
             <div className="h-[4rem]">
-                <BackHeader title="유형연습 Q8-10 복습" hideLogButton={false} />
+                <BackHeader
+                    title={fetchedStamp?.stampName}
+                    hideLogButton={false}
+                />
             </div>
 
             <div className="flex-1 overflow-y-auto pt-3">

--- a/src/pages/trip/dashboard/DashboardPage.tsx
+++ b/src/pages/trip/dashboard/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import MissionListSection from './_components/MissionListSection';
@@ -27,7 +27,6 @@ export default function DashboardPage() {
     const [time, setTime] = useState<TimeValue>({ minute: '30', session: '1' });
 
     const navigate = useNavigate();
-
     const id = useVaildateId();
 
     if (id === null) return null;
@@ -61,6 +60,10 @@ export default function DashboardPage() {
         },
     });
 
+    const handleToggleEditMode = useCallback(() => {
+        setIsEditMode((prev) => !prev);
+    }, []);
+
     const {
         missions,
         allChecked,
@@ -70,7 +73,7 @@ export default function DashboardPage() {
         updateLabel,
         deleteMission,
         toggleCheck,
-        updateMissionOrder,
+        handleToggleEdit,
     } = useDashboardMissions(id.tripId!, id.stampId!, fetchedMissions);
 
     if (isMissionLoading) return <div>미션 목록 로드 중...</div>;
@@ -114,18 +117,16 @@ export default function DashboardPage() {
                     checkedCount={checkedCount}
                 />
                 <MissionListSection
-                    tripId={id.tripId!}
-                    stampId={id.stampId!}
                     missions={missions}
                     allChecked={allChecked}
                     checkedCount={checkedCount}
                     isEditMode={isEditMode}
+                    onToggleEditMode={handleToggleEditMode}
                     addMission={addMission}
-                    onToggleEditMode={() => setIsEditMode((prev) => !prev)}
                     onUpdateLabel={updateLabel}
                     onDelete={deleteMission}
                     onToggleCheck={toggleCheck}
-                    onUpdateMissionOrder={updateMissionOrder}
+                    handleToggleEdit={handleToggleEdit}
                 />
             </div>
 

--- a/src/pages/trip/dashboard/DashboardPage.tsx
+++ b/src/pages/trip/dashboard/DashboardPage.tsx
@@ -20,6 +20,7 @@ import useCreateDailyGoal, {
 } from '../../../hooks/dailyGoal/useCreateDailyGoal';
 
 import useDetailStampQuery from '../../../hooks/stamp/useDetailStampQuery';
+import useCompleteStamp from '../../../hooks/stamp/useCompleteStamp';
 
 export default function DashboardPage() {
     const [isEditMode, setIsEditMode] = useState(false);
@@ -60,6 +61,8 @@ export default function DashboardPage() {
         },
     });
 
+    const { mutateCompleteStamp } = useCompleteStamp();
+
     const handleToggleEditMode = useCallback(() => {
         setIsEditMode((prev) => !prev);
     }, []);
@@ -67,7 +70,7 @@ export default function DashboardPage() {
     const {
         missions,
         allCompletedMission,
-        checkedCount,
+        completedCount,
         checkedMissionIds,
         addMission,
         updateLabel,
@@ -84,6 +87,23 @@ export default function DashboardPage() {
 
     const handleOpen = () => setOpen(true);
     const handleClose = () => setOpen(false);
+
+    const checkedCount = checkedMissionIds.length;
+
+    const buttonText = allCompletedMission
+        ? '스탬프 완료하기'
+        : '학습 시작하기';
+
+    const handleButtonClick = () => {
+        if (buttonText === '학습 시작하기' && missions.length && checkedCount) {
+            handleOpen();
+        }
+
+        if (buttonText === '스탬프 완료하기') {
+            mutateCompleteStamp({ tripId: id.tripId!, stampId: id.stampId! });
+            navigate(-1);
+        }
+    };
 
     const handleConfirm = () => {
         setOpen(false);
@@ -114,11 +134,11 @@ export default function DashboardPage() {
             <div className="flex-1 overflow-y-auto pt-3">
                 <MissionSummary
                     missions={missions}
-                    checkedCount={checkedCount}
+                    completedCount={completedCount}
                 />
                 <MissionListSection
                     missions={missions}
-                    checkedCount={checkedCount}
+                    completedCount={completedCount}
                     isEditMode={isEditMode}
                     allCompleted={allCompletedMission}
                     onToggleEditMode={handleToggleEditMode}
@@ -131,8 +151,11 @@ export default function DashboardPage() {
             </div>
 
             <div className="pb-6">
-                <MainButton onClick={handleOpen} colorClass="bg-text-sub">
-                    {allCompletedMission ? '스탬프 완료하기' : '학습 시작하기'}
+                <MainButton
+                    onClick={handleButtonClick}
+                    colorClass="bg-text-sub"
+                >
+                    {buttonText}
                 </MainButton>
             </div>
 

--- a/src/pages/trip/dashboard/_components/MissionCard.tsx
+++ b/src/pages/trip/dashboard/_components/MissionCard.tsx
@@ -70,7 +70,7 @@ const MissionCard: React.FC<MissionCardProps> = ({
                 </button>
             ) : (
                 <input
-                    checked={isChecked}
+                    checked={mission.completed || isChecked}
                     onChange={() => onToggleCheck(mission.missionId)}
                     type="checkbox"
                     className="accent-text-sub ml-4 h-5 w-5"

--- a/src/pages/trip/dashboard/_components/MissionListSection.tsx
+++ b/src/pages/trip/dashboard/_components/MissionListSection.tsx
@@ -1,81 +1,34 @@
-import { useCallback } from 'react';
-import { v4 as uuidv4 } from 'uuid';
-
 import PlusIcon from '../../../../assets/icons/roundedPlus.svg?react';
 import MissionCard from '../_components/MissionCard';
 
 import { type MissionItem } from '../../../../types/mission/Mission';
-import useCreateMission from '../../../../hooks/mission/useCreateMission';
 
 interface MissionListSectionProps {
-    tripId: number;
-    stampId: number;
     missions: MissionItem[];
     allChecked: boolean;
     checkedCount: number;
     isEditMode: boolean;
+
     addMission: () => void;
-    onToggleEditMode: () => void;
     onUpdateLabel: (id: number | string, value: string) => void;
     onDelete: (id: number | string) => void;
     onToggleCheck: (id: number | string) => void;
-    onUpdateMissionOrder: (newMissions: MissionItem[]) => void;
+    handleToggleEdit: (id: number | string) => void;
+    onToggleEditMode: () => void;
 }
 
 const MissionListSection = ({
-    tripId,
-    stampId,
     missions,
     allChecked,
     checkedCount,
     isEditMode,
+    addMission,
     onToggleEditMode,
     onUpdateLabel,
     onDelete,
     onToggleCheck,
-    onUpdateMissionOrder,
+    handleToggleEdit,
 }: MissionListSectionProps) => {
-    const { mutateCreateMission } = useCreateMission();
-
-    const handleAddMission = useCallback(async () => {
-        const newMissionId = uuidv4();
-
-        const newMission: MissionItem = {
-            missionId: newMissionId,
-            missionName: '',
-            completed: false,
-            isEditing: true,
-            isChecked: false,
-        };
-
-        const updatedMissions = [...missions, newMission];
-
-        onUpdateMissionOrder(updatedMissions);
-    }, [missions, onUpdateMissionOrder]);
-
-    const handleToggleEdit = useCallback(
-        (id: number | string) => {
-            const updatedMissions = missions.map((mission) =>
-                mission.missionId === id
-                    ? { ...mission, isEditing: !mission.isEditing }
-                    : mission
-            );
-
-            onUpdateMissionOrder(updatedMissions);
-
-            const lastIndex = updatedMissions.length - 1;
-
-            mutateCreateMission({
-                tripId,
-                stampId,
-                missionContent: {
-                    missionName: updatedMissions[lastIndex].missionName,
-                },
-            });
-        },
-        [missions, onUpdateMissionOrder]
-    );
-
     return (
         <section className="pt-[3.25rem]">
             {/* 헤더 영역 */}
@@ -96,7 +49,7 @@ const MissionListSection = ({
                         type="button"
                         aria-label="미션 추가"
                         className="cursor-pointer"
-                        onClick={handleAddMission}
+                        onClick={addMission}
                     >
                         <PlusIcon aria-hidden="true" />
                     </button>

--- a/src/pages/trip/dashboard/_components/MissionListSection.tsx
+++ b/src/pages/trip/dashboard/_components/MissionListSection.tsx
@@ -2,10 +2,11 @@ import PlusIcon from '../../../../assets/icons/roundedPlus.svg?react';
 import MissionCard from '../_components/MissionCard';
 
 import { type MissionItem } from '../../../../types/mission/Mission';
+import { useMemo } from 'react';
 
 interface MissionListSectionProps {
     missions: MissionItem[];
-    allChecked: boolean;
+    allCompleted: boolean;
     checkedCount: number;
     isEditMode: boolean;
 
@@ -19,7 +20,7 @@ interface MissionListSectionProps {
 
 const MissionListSection = ({
     missions,
-    allChecked,
+    allCompleted,
     checkedCount,
     isEditMode,
     addMission,
@@ -34,9 +35,12 @@ const MissionListSection = ({
             {/* 헤더 영역 */}
             <div className="flex items-center justify-between">
                 <span className="text-body font-semibold">
-                    {missions.length
-                        ? `오늘의 미션, ${missions.length - checkedCount}개 남았어요!`
-                        : '오늘의 미션을 먼저 설정해 주세요!'}
+                    {allCompleted && '오늘의 미션을 모두 완료했어요!'}
+                    {!allCompleted
+                        ? missions.length
+                            ? `오늘의 미션, ${missions.length - checkedCount}개 남았어요!`
+                            : '오늘의 미션을 먼저 설정해 주세요!'
+                        : undefined}
                 </span>
                 <div className="flex items-center gap-3">
                     <button
@@ -56,7 +60,7 @@ const MissionListSection = ({
                 </div>
             </div>
             {/* 서브 텍스트 */}
-            {allChecked && (
+            {allCompleted && (
                 <span className="text-sm text-[#585858]">
                     더 학습하고 싶다면 미션을 추가해 보세요.
                 </span>

--- a/src/pages/trip/dashboard/_components/MissionListSection.tsx
+++ b/src/pages/trip/dashboard/_components/MissionListSection.tsx
@@ -2,7 +2,6 @@ import PlusIcon from '../../../../assets/icons/roundedPlus.svg?react';
 import MissionCard from '../_components/MissionCard';
 
 import { type MissionItem } from '../../../../types/mission/Mission';
-import { useMemo } from 'react';
 
 interface MissionListSectionProps {
     missions: MissionItem[];

--- a/src/pages/trip/dashboard/_components/MissionListSection.tsx
+++ b/src/pages/trip/dashboard/_components/MissionListSection.tsx
@@ -81,11 +81,9 @@ const MissionListSection = ({
             {/* 헤더 영역 */}
             <div className="flex items-center justify-between">
                 <span className="text-body font-semibold">
-                    {allChecked
-                        ? '오늘의 미션을 모두 완료했어요!'
-                        : missions.length
-                          ? `오늘의 미션, ${missions.length - checkedCount}개 남았어요!`
-                          : '오늘의 미션을 먼저 설정해 주세요!'}
+                    {missions.length
+                        ? `오늘의 미션, ${missions.length - checkedCount}개 남았어요!`
+                        : '오늘의 미션을 먼저 설정해 주세요!'}
                 </span>
                 <div className="flex items-center gap-3">
                     <button

--- a/src/pages/trip/dashboard/_components/MissionListSection.tsx
+++ b/src/pages/trip/dashboard/_components/MissionListSection.tsx
@@ -6,7 +6,7 @@ import { type MissionItem } from '../../../../types/mission/Mission';
 interface MissionListSectionProps {
     missions: MissionItem[];
     allCompleted: boolean;
-    checkedCount: number;
+    completedCount: number;
     isEditMode: boolean;
 
     addMission: () => void;
@@ -20,7 +20,7 @@ interface MissionListSectionProps {
 const MissionListSection = ({
     missions,
     allCompleted,
-    checkedCount,
+    completedCount,
     isEditMode,
     addMission,
     onToggleEditMode,
@@ -37,7 +37,7 @@ const MissionListSection = ({
                     {allCompleted && '오늘의 미션을 모두 완료했어요!'}
                     {!allCompleted
                         ? missions.length
-                            ? `오늘의 미션, ${missions.length - checkedCount}개 남았어요!`
+                            ? `오늘의 미션, ${missions.length - completedCount}개 남았어요!`
                             : '오늘의 미션을 먼저 설정해 주세요!'
                         : undefined}
                 </span>

--- a/src/pages/trip/dashboard/_components/MissionSummary.tsx
+++ b/src/pages/trip/dashboard/_components/MissionSummary.tsx
@@ -10,6 +10,10 @@ interface MissionSummaryProps {
 }
 
 const MissionSummary = ({ missions, checkedCount }: MissionSummaryProps) => {
+    const completedMissionCount = missions.filter(
+        (mission) => mission.completed
+    ).length;
+
     return (
         <section className="">
             <div className="bg-plus-background flex shrink-0 flex-col rounded-xl p-4">
@@ -38,7 +42,7 @@ const MissionSummary = ({ missions, checkedCount }: MissionSummaryProps) => {
                         {missions.map((mission, index) => (
                             <SessionGraph
                                 key={mission.missionId}
-                                isCompleted={mission.isChecked}
+                                isCompleted={index < completedMissionCount}
                                 isLast={index === missions.length - 1}
                             />
                         ))}

--- a/src/pages/trip/dashboard/_components/MissionSummary.tsx
+++ b/src/pages/trip/dashboard/_components/MissionSummary.tsx
@@ -34,7 +34,7 @@ const MissionSummary = ({ missions, checkedCount }: MissionSummaryProps) => {
                     )}
                 </div>
                 {missions.length ? (
-                    <div className="flex h-13 overflow-x-hidden pt-5">
+                    <div className="flex h-13 overflow-x-scroll pt-5 [&::-webkit-scrollbar]:hidden">
                         {missions.map((mission, index) => (
                             <SessionGraph
                                 key={mission.missionId}

--- a/src/pages/trip/dashboard/_components/MissionSummary.tsx
+++ b/src/pages/trip/dashboard/_components/MissionSummary.tsx
@@ -6,10 +6,10 @@ import { type MissionItem } from '../../../../types/mission/Mission';
 
 interface MissionSummaryProps {
     missions: MissionItem[];
-    checkedCount: number;
+    completedCount: number;
 }
 
-const MissionSummary = ({ missions, checkedCount }: MissionSummaryProps) => {
+const MissionSummary = ({ missions, completedCount }: MissionSummaryProps) => {
     const completedMissionCount = missions.filter(
         (mission) => mission.completed
     ).length;
@@ -22,7 +22,7 @@ const MissionSummary = ({ missions, checkedCount }: MissionSummaryProps) => {
                         <div className="flex w-full flex-col gap-1">
                             <div className="flex justify-between">
                                 <h5 className="text-text-sub text-xl font-bold">
-                                    {`${checkedCount}/${missions.length} 세션 진행 중`}
+                                    {`${completedCount}/${missions.length} 세션 진행 중`}
                                 </h5>
                                 {/* <CalendarButton /> */}
                             </div>

--- a/src/pages/trip/dashboard/_components/MissionSummary.tsx
+++ b/src/pages/trip/dashboard/_components/MissionSummary.tsx
@@ -1,4 +1,4 @@
-import CalendarButton from '../_components/CalendarButton';
+// import CalendarButton from '../_components/CalendarButton';
 import SessionGraph from '../_components/SessionGraph/SessionGraph';
 import WriteIcon from '../../../../assets/icons/write.svg?react';
 
@@ -20,9 +20,9 @@ const MissionSummary = ({ missions, checkedCount }: MissionSummaryProps) => {
                                 <h5 className="text-text-sub text-xl font-bold">
                                     {`${checkedCount}/${missions.length} 세션 진행 중`}
                                 </h5>
-                                <CalendarButton />
+                                {/* <CalendarButton /> */}
                             </div>
-                            <span className="text-text-sub">1:30:00</span>
+                            {/* <span className="text-text-sub">1:30:00</span> */}
                         </div>
                     ) : (
                         <>

--- a/src/pages/trip/dashboard/_hooks/useDashboardMissions.ts
+++ b/src/pages/trip/dashboard/_hooks/useDashboardMissions.ts
@@ -164,8 +164,10 @@ export const useDashboardMissions = (
         [setMissions]
     );
 
-    const allChecked = useMemo(
-        () => missions.every((mission) => mission.completed),
+    const allCompletedMission = useMemo(
+        () =>
+            missions.filter((mission) => mission.completed).length ===
+            missions.length,
         [missions]
     );
 
@@ -184,7 +186,7 @@ export const useDashboardMissions = (
 
     return {
         missions,
-        allChecked,
+        allCompletedMission,
         checkedCount,
         checkedMissionIds,
         addMission,

--- a/src/pages/trip/dashboard/_hooks/useDashboardMissions.ts
+++ b/src/pages/trip/dashboard/_hooks/useDashboardMissions.ts
@@ -166,8 +166,9 @@ export const useDashboardMissions = (
 
     const allCompletedMission = useMemo(
         () =>
+            missions.length !== 0 &&
             missions.filter((mission) => mission.completed).length ===
-            missions.length,
+                missions.length,
         [missions]
     );
 

--- a/src/pages/trip/dashboard/_hooks/useDashboardMissions.ts
+++ b/src/pages/trip/dashboard/_hooks/useDashboardMissions.ts
@@ -180,7 +180,7 @@ export const useDashboardMissions = (
         [missions]
     );
 
-    const checkedCount = useMemo(
+    const completedCount = useMemo(
         () => missions.filter((mission) => mission.completed).length,
         [missions]
     );
@@ -188,7 +188,7 @@ export const useDashboardMissions = (
     return {
         missions,
         allCompletedMission,
-        checkedCount,
+        completedCount,
         checkedMissionIds,
         addMission,
         updateLabel,

--- a/src/pages/trip/dashboard/_hooks/useDashboardMissions.ts
+++ b/src/pages/trip/dashboard/_hooks/useDashboardMissions.ts
@@ -1,5 +1,7 @@
+import { useAtom } from 'jotai';
 import { useState, useMemo, useCallback, useEffect } from 'react';
 
+import { missionsAtom } from '../../../../store/mission';
 import { type MissionItem } from '../../../../types/mission/Mission';
 import useDeleteMission from '../../../../hooks/mission/useDeleteMission';
 import usePatchMission from '../../../../hooks/mission/usePatchMission';
@@ -12,7 +14,7 @@ export const useDashboardMissions = (
         | Omit<MissionItem, 'isEditing' | 'isChecked'>[]
         | undefined
 ) => {
-    const [missions, setMissions] = useState<MissionItem[]>([]);
+    const [missions, setMissions] = useAtom(missionsAtom);
     const [debouncedUpdate, setDebouncedUpdate] = useState<{
         id: number | string;
         value: string;
@@ -69,7 +71,7 @@ export const useDashboardMissions = (
     const checkedMissionIds = useMemo(
         () =>
             missions
-                .filter((mission) => mission.isChecked)
+                .filter((mission) => mission.isChecked && !mission.completed)
                 .map((mission) => mission.missionId),
         [missions]
     );
@@ -110,11 +112,13 @@ export const useDashboardMissions = (
     // 미션 체크 상태 토글
     const toggleCheck = useCallback((id: number | string) => {
         setMissions((prev) =>
-            prev.map((mission) =>
-                mission.missionId === id
-                    ? { ...mission, isChecked: !mission.isChecked }
-                    : mission
-            )
+            prev.map((mission) => {
+                if (mission.missionId === id && !mission.completed) {
+                    return { ...mission, isChecked: !mission.isChecked };
+                }
+
+                return mission;
+            })
         );
     }, []);
 

--- a/src/services/stamp/stamps.ts
+++ b/src/services/stamp/stamps.ts
@@ -19,3 +19,21 @@ export const fetchStampDetail = async (
         );
     }
 };
+
+export const completeStamp = async (tripId: number, stampId: number) => {
+    try {
+        const { data } = await api.patch(
+            `/api/trips/${tripId}/stamps/${stampId}/complete`
+        );
+
+        return data.data;
+    } catch (error: unknown) {
+        if ((error as any).response?.status === 404) {
+            throw new Error('스탬프를 완료 할 수 없습니다.');
+        }
+
+        throw new Error(
+            '스탬프를 완료하지 못했습니다. 잠시 후에 다시 시도해 주세요.'
+        );
+    }
+};

--- a/src/services/stamp/stamps.ts
+++ b/src/services/stamp/stamps.ts
@@ -23,7 +23,7 @@ export const fetchStampDetail = async (
 export const completeStamp = async (tripId: number, stampId: number) => {
     try {
         const { data } = await api.patch(
-            `/api/trips/${tripId}/stamps/${stampId}/complete`
+            `/trips/${tripId}/stamps/${stampId}/complete`
         );
 
         return data.data;

--- a/src/services/stamp/stamps.ts
+++ b/src/services/stamp/stamps.ts
@@ -1,0 +1,21 @@
+import api from '../../lib/axios';
+import type { StampDetail } from '../../types/stamp';
+
+export const fetchStampDetail = async (
+    tripId: number,
+    stampId: number
+): Promise<StampDetail> => {
+    try {
+        const { data } = await api.get(`/trips/${tripId}/stamps/${stampId}`);
+
+        return data.data;
+    } catch (error: unknown) {
+        if ((error as any)?.response.status === 404) {
+            throw new Error('스탬프를 조회할 수 없습니다.');
+        }
+
+        throw new Error(
+            '스탬프를 조회하지 못했습니다. 잠시 후에 다시 시도해 주세요.'
+        );
+    }
+};

--- a/src/store/mission.ts
+++ b/src/store/mission.ts
@@ -1,0 +1,4 @@
+import { atom } from 'jotai';
+import type { MissionItem } from '../types/mission/Mission';
+
+export const missionsAtom = atom<MissionItem[]>([]);

--- a/src/types/stamp.ts
+++ b/src/types/stamp.ts
@@ -1,3 +1,14 @@
+export interface ResponseDTO {
+    success: boolean;
+    status: number;
+    data: null;
+}
+
+export interface MutationStampProps {
+    tripId: number;
+    stampId: number;
+}
+
 export interface StampDetail {
     stampId: number;
     stampName: string;

--- a/src/types/stamp.ts
+++ b/src/types/stamp.ts
@@ -1,0 +1,7 @@
+export interface StampDetail {
+    stampId: number;
+    stampName: string;
+    stampOrder: number;
+    completed: boolean;
+    missions: number[];
+}


### PR DESCRIPTION
## 🔗 관련 이슈

https://ject-plog.atlassian.net/browse/SCRUM-67

## 📌 Summary

> @지영 님이 말씀해 주신 스탬프 대시보드 페이지에 존재하던 버그 몇 가지를 수정했습니다. 수정된 버그 목록은 아래와 같습니다.

- 로드맵에서 스탬프 위치가 이상하게 표시되는 버그 수정 (design)
- 헤더에 특정 스탬프 제목이 잘못 표시되는 버그 수정
- 미션이 없을 때 문구가 잘못 표시되는 버그 수정
- 미션 카드 클릭 시 미션이 복제되는 버그 수정

> 이 과정에서 추가된 API 연결 목록은 아래와 같습니다.

- 스탬프 상세 조회 API 연결
- 스탬프 완료 API 연결

> 추가적으로 발견한 버그 및 개선 사항을 수정했습니다. 수정 사항은 아래와 같습니다.

- 학습 완료된 세션에 포함된 미션이 완료로 표시되지 않던 버그 수정
  - 완료된 미션을 사용자가 임의로 토글할 수 없도록 입력 제한
- 세션 현황 그래프의 완료 순서가 순차적이지 않게 표시되던 버그 수정
- 스탬프 제목이 길어질 경우 말줄임 표시
- 학습 시작 버튼 동작 제한

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 변경 사항

### 1. 로드맵 UI 관련 수정 사항

_**로드맵에서 스탬프 위치가 이상하게 표시되는 버그 수정**_

> 로드맵에서 스탬프 위치가 이상하게 표시되는 버그를 수정했습니다. 기존에 **`padding` 속성만으로 스타일을 조정**하려고 했던 게 버그의 원인이라고 판단되어 `position` 속성을 추가했습니다. 이 과정에서 스탬프 이름이 길어질수록 UI가 깨지는 현상이 발생해 `line-clamp-2`를 적용해 말줄임이 표시될 수 있도록 추가 구현했습니다.

```ts
export const alignStyleClass = {
    ...
    center: 'absolute justify-center top-[-30%] left-[58%] transform translate-x-[-50%] translate-y-[-50%]',
} as const;

/* GoalStep.tsx 최상위 태그 */
<div className="relative flex flex-col">
```

<img width="388" height="724" alt="image" src="https://github.com/user-attachments/assets/c84bcc07-2581-49fb-a975-14d0ba12e507" />

<img width="376" height="666" alt="스크린샷 2025-08-17 오후 4 37 16" src="https://github.com/user-attachments/assets/9d2f4cf5-11c3-4e96-b423-9e30e9d9168b" />

### 2. 헤더에 특정 스탬프 제목이 잘못 표시되는 버그 수정

> 헤더에 특정 스탬프 제목이 잘못 표시되는 버그를 수정했습니다. 기존 **하드 코딩된 텍스트를 대체하지 않아 발생**한 버그였습니다. `스탬프 상세 조회 API hook(useDetailStampQuery)`을 연결해 해결해 주었습니다. 이 과정에서 스탬프 이름이 한 줄이 넘어가면 UI가 깨지는 현상이 발생해 `line-clamp-1`을 적용해 말줄임이 표시될 수 있도록 추가 구현했습니다.

<img width="388" height="870" alt="image" src="https://github.com/user-attachments/assets/7d9c752e-f0b9-44e3-9aca-e119a58e91af" />

<img width="375" height="665" alt="스크린샷 2025-08-17 오후 4 41 14" src="https://github.com/user-attachments/assets/de37b96e-aa96-47fa-b4d4-da280c78ae2d" />


## 📜 공유 사항

- 공부 기록 생성 후 미션 완료 여부 업데이트가 즉시 반영되지 않음 (새로 고침 필요)
- 스탬프 완료 후 완료 여부 업데이트가 즉시 반영되지 않음 (새로 고침 필요)

## 📱 스크린샷/화면 기록

> 변경 사항에 모두 첨부해 두겠습니다.



