### PR TITLE
fix[#68]: 공부 기록 생성 후 미션 완료 여부 업데이트가 즉시 반영되지 않는 버그 수정

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-54d0af47'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.q2co5ffmlc"
+    "revision": "0.re5heovfvg"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/hooks/stamp/useCompleteStamp.ts
+++ b/src/hooks/stamp/useCompleteStamp.ts
@@ -1,7 +1,8 @@
+import { toast } from 'react-toastify';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { completeStamp } from '../../services/stamp/stamps';
 import type { ResponseDTO, MutationStampProps } from '../../types/stamp';
-import { toast } from 'react-toastify';
 
 const useCompleteStamp = () => {
     const queryClient = useQueryClient();
@@ -16,7 +17,7 @@ const useCompleteStamp = () => {
         },
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({
-                queryKey: ['stamp', variables.tripId, variables.stampId],
+                queryKey: ['tripDetail', variables.tripId],
             });
         },
         onError: () => {

--- a/src/pages/pomodoro/log/LogPage.tsx
+++ b/src/pages/pomodoro/log/LogPage.tsx
@@ -1,5 +1,5 @@
-import { useSetAtom } from 'jotai';
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import api from '@lib/axios';
@@ -8,7 +8,6 @@ import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 import MainButton from '../../../components/common/button/MainButton';
 import LogMissionItem from './LogMissionItem';
-import { missionsAtom } from '../../../store/mission';
 
 interface DailyMission {
     dailyMissionId: number;
@@ -17,12 +16,11 @@ interface DailyMission {
 }
 
 const LogPage = () => {
-    const setMissions = useSetAtom(missionsAtom);
-
     const navigate = useNavigate();
     const location = useLocation();
+    const queryClient = useQueryClient();
 
-    const { tripId, dailyGoal } = location.state || {};
+    const { tripId, dailyGoal, stampId } = location.state || {};
     console.log(dailyGoal);
 
     if (!tripId || !dailyGoal) {
@@ -47,6 +45,7 @@ const LogPage = () => {
         const sec = Math.floor(seconds % 60);
         return `${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
     };
+
     const timeSpent = formatTime(dailyGoal.elapsedTime);
 
     const [checkedIds, setCheckedIds] = useState<number[]>(() =>
@@ -75,15 +74,9 @@ const LogPage = () => {
                 }
             );
 
-            setMissions((prevMissions) =>
-                prevMissions.map((mission) => {
-                    if (checkedIds.includes(Number(mission.missionId))) {
-                        return { ...mission, completed: true, isChecked: true };
-                    }
-
-                    return mission;
-                })
-            );
+            queryClient.invalidateQueries({
+                queryKey: ['missions', tripId, stampId],
+            });
 
             alert('공부 기록이 생성되었습니다.');
 

--- a/src/pages/pomodoro/log/LogPage.tsx
+++ b/src/pages/pomodoro/log/LogPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import api from '@lib/axios';
@@ -8,6 +8,7 @@ import { CircularProgressbar, buildStyles } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 import MainButton from '../../../components/common/button/MainButton';
 import LogMissionItem from './LogMissionItem';
+import { missionRefetchAtom } from '../../../store/mission';
 
 interface DailyMission {
     dailyMissionId: number;
@@ -16,11 +17,11 @@ interface DailyMission {
 }
 
 const LogPage = () => {
+    const missionRefetch = useAtomValue(missionRefetchAtom);
     const navigate = useNavigate();
     const location = useLocation();
-    const queryClient = useQueryClient();
 
-    const { tripId, dailyGoal, stampId } = location.state || {};
+    const { tripId, dailyGoal } = location.state || {};
     console.log(dailyGoal);
 
     if (!tripId || !dailyGoal) {
@@ -74,9 +75,7 @@ const LogPage = () => {
                 }
             );
 
-            queryClient.invalidateQueries({
-                queryKey: ['missions', tripId, stampId],
-            });
+            if (missionRefetch) await missionRefetch();
 
             alert('공부 기록이 생성되었습니다.');
 

--- a/src/pages/trip/dashboard/DashboardPage.tsx
+++ b/src/pages/trip/dashboard/DashboardPage.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 
 import MissionListSection from './_components/MissionListSection';
@@ -21,11 +22,14 @@ import useCreateDailyGoal, {
 
 import useDetailStampQuery from '../../../hooks/stamp/useDetailStampQuery';
 import useCompleteStamp from '../../../hooks/stamp/useCompleteStamp';
+import { missionRefetchAtom } from '../../../store/mission';
 
 export default function DashboardPage() {
     const [isEditMode, setIsEditMode] = useState(false);
     const [open, setOpen] = useState(false);
     const [time, setTime] = useState<TimeValue>({ minute: '30', session: '1' });
+
+    const [, setMissionRefetch] = useAtom(missionRefetchAtom);
 
     const navigate = useNavigate();
     const id = useVaildateId();
@@ -36,7 +40,12 @@ export default function DashboardPage() {
         data: fetchedMissions,
         isLoading: isMissionLoading,
         isError: isMissionError,
+        refetch,
     } = useMissionQuery(id.tripId!, id.stampId!);
+
+    useEffect(() => {
+        setMissionRefetch(() => refetch);
+    }, [refetch, setMissionRefetch]);
 
     const {
         data: fetchedStamp,

--- a/src/pages/trip/dashboard/_hooks/useDashboardMissions.ts
+++ b/src/pages/trip/dashboard/_hooks/useDashboardMissions.ts
@@ -3,7 +3,10 @@ import { useState, useMemo, useCallback, useEffect } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { missionsAtom } from '../../../../store/mission';
-import { type MissionItem } from '../../../../types/mission/Mission';
+import type {
+    MissionItem,
+    ServerMissionItem,
+} from '../../../../types/mission/Mission';
 import useDeleteMission from '../../../../hooks/mission/useDeleteMission';
 import usePatchMission from '../../../../hooks/mission/usePatchMission';
 import useCreateMission from '../../../../hooks/mission/useCreateMission';
@@ -11,9 +14,7 @@ import useCreateMission from '../../../../hooks/mission/useCreateMission';
 export const useDashboardMissions = (
     tripId: number,
     stampId: number,
-    initialFetchedMissions?:
-        | Omit<MissionItem, 'isEditing' | 'isChecked'>[]
-        | undefined
+    initialFetchedMissions?: ServerMissionItem[] | undefined
 ) => {
     const [missions, setMissions] = useAtom(missionsAtom);
     const [debouncedUpdate, setDebouncedUpdate] = useState<{
@@ -33,9 +34,10 @@ export const useDashboardMissions = (
                     missionName: m.missionName,
                     completed: m.completed,
                     isEditing: false,
-                    isChecked: false,
+                    isChecked: m.completed || false,
                 })
             );
+
             setMissions(convertedMissions);
         }
     }, [initialFetchedMissions, setMissions]);

--- a/src/store/mission.ts
+++ b/src/store/mission.ts
@@ -1,4 +1,15 @@
 import { atom } from 'jotai';
-import type { MissionItem } from '../types/mission/Mission';
+import type {
+    QueryObserverResult,
+    RefetchOptions,
+} from '@tanstack/react-query';
+import type { MissionItem, ServerMissionItem } from '../types/mission/Mission';
+
+type RefetchMissions =
+    | ((
+          options?: RefetchOptions
+      ) => Promise<QueryObserverResult<ServerMissionItem[], Error>>)
+    | null;
 
 export const missionsAtom = atom<MissionItem[]>([]);
+export const missionRefetchAtom = atom<RefetchMissions>(null);


### PR DESCRIPTION
## 🔗 관련 이슈

https://ject-plog.atlassian.net/browse/SCRUM-68

## 📌 Summary

- 공부 기록 생성 후 미션 완료 여부 업데이트가 즉시 반영되지 않는 버그 수정

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 변경 사항

> `navigate(-1)`을 통해 `DashboardPage`로 이동하는 과정에서 마운트가 발생할 것으로 예상했지만, 마운트가 발생하지 않고 캐시된 데이터를 사용해 `useQuery` 훅이 다시 실행되지 않아 발생하는 문제였습니다. `invalidateQueries`를 사용해 문제를 해결하려 했으나 재패치 자체가 되지 않고 있음을 인지하고 학습 완료 시 `refetch`를 수행하도록 변경했습니다.


