### PR TITLE
fix: navigate 경로 명시 

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-54d0af47'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.re5heovfvg"
+    "revision": "0.05efv2st3v8"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/pages/trip/dashboard/DashboardPage.tsx
+++ b/src/pages/trip/dashboard/DashboardPage.tsx
@@ -91,7 +91,7 @@ export default function DashboardPage() {
 
         if (buttonText === '스탬프 완료하기') {
             mutateCompleteStamp({ tripId: id.tripId!, stampId: id.stampId! });
-            navigate(-1);
+            navigate(`/trip/${id.tripId}`);
         }
     };
 


### PR DESCRIPTION
## 📌 Summary

- navigate 경로 명시 

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 변경 사항

> `/trip/:tripId/dashboard`에서 스탬프 완료하기 버튼 클릭 시 라우팅이 정상적으로 이루어지지 않는 버그가 발생했습니다. `navigate(-1)`이 문제의 원인이라 판단해 이동할 경로를 명시해 주었습니다. `/trip/${tripId}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 없음
- 버그 수정
  - 스탬프 완료 후 이동 경로를 이전 페이지로 돌아가던 방식에서 해당 여행 페이지로 바로 이동하도록 변경하여 흐름을 명확히 했습니다.
- 기타(Chores)
  - 서비스 워커의 프리캐시 매니페스트를 최신 상태로 갱신해 초기 로딩 캐시를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->